### PR TITLE
Makes regex less greedy

### DIFF
--- a/src/processor.rs
+++ b/src/processor.rs
@@ -42,13 +42,13 @@ fn process_hash(hash: &mut Hash, parameters: &ParamMap) -> ProcessorResult {
 fn process_string(string: &mut String, parameters: &ParamMap) -> ProcessorResult {
     lazy_static! {
         static ref LITERAL_INTERPOLATION: Regex = Regex::new(
-            r"\$\({2}(.*)\){2}"
+            r"\$\({2}([^\)]*)\){2}"
         ).expect("Failed to compile regex.");
     }
 
     lazy_static! {
         static ref STRING_INTERPOLATION: Regex = Regex::new(
-            r"\$\((.*)\)"
+            r"\$\(([^\)]*)\)"
         ).expect("Failed to compile regex.");
     }
 


### PR DESCRIPTION
The regexes were too greedy, and that would lead to an issue
when trying to match multiple interpolation on a same line.

$(test)_$(test2) should lead to two matches which are test and test2
but instead you will match test)_$(test2 and therefor interpolation
would fail

This commit fixes it
